### PR TITLE
Fix typo and url error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ gulp watch
 |[league/html-to-markdown](https://github.com/thephpleague/html-to-markdown)| 将 HTML 转换成 Markdown| 用户发帖、回复帖子时使用了此扩展包。 |
 |[erusev/parsedown](https://github.com/erusev/parsedown)| 将 Markdown 转换成 HTML| 用户发帖、回复帖子时使用了此扩展包。 |
 | [laravel/socialite](https://github.com/laravel/socialite) | 官方社会化登录组件 | GitHub 登录逻辑使用了此扩展包。 |
-|[naux/auto-correct](github.com/NauxLiu/auto-correct)| 自动给中英文之间加入合理的空格，纠正专用名词大小写| 用户发帖时用此扩展包过滤标题。 |
+|[NauxLiu/auto-correct](https://github.com/NauxLiu/auto-correct)| 自动给中英文之间加入合理的空格，纠正专用名词大小写| 用户发帖时用此扩展包过滤标题。 |
 | [Intervention/image](https://github.com/Intervention/image) | 图片处理功能库 | 用发帖和回复帖子时，图片上传的逻辑使用了此扩展包。 |
 | [zizaco/entrust](https://github.com/Zizaco/entrust.git) | 用户组权限系统 | 整站的权限系统基于此扩展包开发。 |
 | [VentureCraft/revisionable](https://github.com/VentureCraft/revisionable) | 记录 Model 的变更日志 | 以下 Model: User, Topic, Reply, Category, Banner 都用此扩展包记录删除日志。|


### PR DESCRIPTION
Typo:
naux/auto-correct => NauxLiu/auto-correct

Url error:
In Markdown, the text `[NauxLiu/auto-correct](https://github.com/NauxLiu/auto-correct)` is parsed to HTML `<a href="/summerblue/phphub5/blob/master/github.com/NauxLiu/auto-correct">Nnaux/auto-correct</a>`, not `<a href="https://github.com/NauxLiu/auto-correct">Nnaux/auto-correct</a>`