### PR TITLE
Fix unique key max length constraint, fixes #47

### DIFF
--- a/database/migrations/2014_04_24_110557_create_oauth_client_endpoints_table.php
+++ b/database/migrations/2014_04_24_110557_create_oauth_client_endpoints_table.php
@@ -30,7 +30,7 @@ class CreateOauthClientEndpointsTable extends Migration
         Schema::create('oauth_client_endpoints', function (Blueprint $table) {
             $table->increments('id');
             $table->string('client_id', 40);
-            $table->string('redirect_uri');
+            $table->string('redirect_uri', 151);
 
             $table->timestamps();
 


### PR DESCRIPTION
[According to mysql document](https://dev.mysql.com/doc/refman/5.7/en/innodb-restrictions.html), the index key prefix length limit is 767 bytes. 

Because of [charset config](https://github.com/summerblue/phphub5/blob/5c7e9d88dc10d90da16a39b4611e7c68af92f6fd/config/database.php#L61), a index max length is 191 ( floor(767/4) ).