### PR TITLE
fix mysql key length limit

### DIFF
--- a/database/migrations/2014_04_24_110459_create_oauth_clients_table.php
+++ b/database/migrations/2014_04_24_110459_create_oauth_clients_table.php
@@ -30,7 +30,7 @@ class CreateOauthClientsTable extends Migration
         Schema::create('oauth_clients', function (BluePrint $table) {
             $table->string('id', 40)->primary();
             $table->string('secret', 40);
-            $table->string('name');
+            $table->string('name', 191);
             $table->unsignedInteger('user_id')->index();
             $table->timestamps();
 

--- a/database/migrations/2014_04_24_110557_create_oauth_client_endpoints_table.php
+++ b/database/migrations/2014_04_24_110557_create_oauth_client_endpoints_table.php
@@ -30,7 +30,7 @@ class CreateOauthClientEndpointsTable extends Migration
         Schema::create('oauth_client_endpoints', function (Blueprint $table) {
             $table->increments('id');
             $table->string('client_id', 40);
-            $table->string('redirect_uri');
+            $table->string('redirect_uri', 191);
 
             $table->timestamps();
 

--- a/database/migrations/2016_05_09_154236_create_tags_table.php
+++ b/database/migrations/2016_05_09_154236_create_tags_table.php
@@ -9,8 +9,8 @@ class CreateTagsTable extends Migration {
 	{
 		Schema::create(config('taggable.tags_table_name'), function(Blueprint $table) {
 			$table->increments('id');
-			$table->string('slug', 255)->unique();
-			$table->string('name', 255)->unique();
+			$table->string('slug', 191)->unique();
+			$table->string('name', 191)->unique();
 			$table->text('description')->nullable();
 			$table->boolean('suggest')->default(false);
 			$table->integer('count')->unsigned()->default(0); // count of how many times this tag was used
@@ -30,7 +30,7 @@ class CreateTagsTable extends Migration {
 			} else {
 				$table->integer('taggable_id')->unsigned()->index();
 			}
-			$table->string('taggable_type', 255)->index();
+			$table->string('taggable_type', 191)->index();
 			$table->integer('tag_id')->unsigned()->index();
 
             $table->foreign('tag_id')

--- a/database/migrations/2016_07_03_021841_create_users_table.php
+++ b/database/migrations/2016_07_03_021841_create_users_table.php
@@ -18,7 +18,7 @@ class CreateUsersTable extends Migration
             $table->integer('github_id')->index();
             $table->string('github_url');
             $table->string('email')->nullable()->index();
-            $table->string('name')->nullable()->index();
+            $table->string('name', 191)->nullable()->index();
             $table->string('login_token')->nullable();
             $table->string('remember_token')->nullable();
             $table->enum('is_banned', ['yes',  'no'])->default('no')->index();

--- a/database/migrations/2016_07_03_222952_entrust_setup_tables.php
+++ b/database/migrations/2016_07_03_222952_entrust_setup_tables.php
@@ -14,7 +14,7 @@ class EntrustSetupTables extends Migration
         // Create table for storing roles
         Schema::create('roles', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name', 191)->unique();
             $table->string('display_name')->nullable();
             $table->string('description')->nullable();
             $table->timestamps();
@@ -36,7 +36,7 @@ class EntrustSetupTables extends Migration
         // Create table for storing permissions
         Schema::create('permissions', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name')->unique();
+            $table->string('name', 191)->unique();
             $table->string('display_name')->nullable();
             $table->string('description')->nullable();
             $table->timestamps();


### PR DESCRIPTION
### 解决数据迁移时的字段长度限制问题：

第一次提mr，将就看咯

出现这个问题的原因是phphub的表的排序规则是utf8mb4，相比utf8多了一个byte。

因此对varchar(255)做索引时，utf8mb4规则下会超过mysql的索引字节限制。

解决方案：把需要加索引的varchar字段长度设置成191
```
$ php artisan est:install
---
php artisan key:generate
Application key [QG9gclaUqnWrCYeyK7dnjzsDPGYxAkpM] set successfully.

---
---
php artisan migrate --seed

                                                                                                                                                           
  [Illuminate\Database\QueryException]                                                                                                                     
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes (SQL: alter table `oauth_client_endpoin  
  ts` add unique `oauth_client_endpoints_client_id_redirect_uri_unique`(`client_id`, `redirect_uri`))                                                      
                                                                                                                                                           

                                                                                                                   
  [PDOException]                                                                                                   
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes  
                                                                                                                  
```